### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,6 +1,5 @@
 name: Bug Report
 description: Report a bug in Miniblox Translation Layer
-type: 'bug'
 labels: [bug]
 body:
 - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,69 @@
+name: Bug Report
+description: Report a bug in Miniblox Translation Layer
+type: 'bug'
+labels: [bug]
+body:
+- type: checkboxes
+  attributes:
+    label: Preflight Checklist
+    description: Please ensure you've completed all of the following.
+    options:
+      - label: I am not a pest
+        required: true
+      - label: I am using the latest version of Miniblox Translation Layer (`git pull`)
+        required: true
+      - label: My Minecraft client is running on 1.8.9 (you can use ViaVersion)
+        required: true
+      - label: I have searched the issues of this repository and believe that this is not a duplicate
+        required: true
+- type: dropdown
+  attributes:
+    label: What OS(es) are you using?
+    multiple: true
+    options:
+      - Windows
+      - macOS
+      - Ubuntu
+      - Other Linux
+      - Other (specify below)
+  validations:
+    required: true
+- type: input
+  attributes:
+    label: Operating System Version
+    description: What operating system version are you using? On Windows, click Start button > Settings > System > About. On macOS, click the Apple Menu > About This Mac. On Linux, use lsb_release or uname -a.
+    placeholder: "e.g. Windows 10 version 1909, macOS Catalina 10.15.7, or Ubuntu 20.04"
+  validations:
+    required: true
+- type: dropdown
+  attributes:
+    label: What architecture are you using?
+    default: 0
+    options:
+      - x64
+      - ia32
+      - arm64 (including Apple Silicon)
+      - Other (specify below)
+  validations:
+    required: true
+- type: input
+  attributes:
+    label: Last Known Working Miniblox Translation Layer commit
+    description: What is the last commit of Miniblox Translation Layer this worked in, if applicable?
+    placeholder: ce088a0
+- type: textarea
+  attributes:
+    label: Expected Behavior
+    description: A clear and concise description of what you expected to happen.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Actual Behavior
+    description: A clear description of what actually happens.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Additional Information
+    description: If your problem needs further explanation, please add more information here.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,42 @@
+name: Feature Request
+description: Suggest an idea for Miniblox Translation Layer
+type: 'enhancement'
+labels: [enhancement]
+body:
+- type: checkboxes
+  attributes:
+    label: Preflight Checklist
+    description: Please ensure you've completed all of the following.
+    options:
+      - label: I am not a pest
+        required: true
+      - label: I am using the latest version of Miniblox Translation Layer (`git pull`)
+        required: true
+      - label: My Minecraft client is running on 1.8.9 (you can use ViaVersion)
+        required: true
+      - label: I have searched the issues of this repository and believe that this is not a duplicate
+        required: true
+- type: textarea
+  attributes:
+    label: Problem Description
+    description: Please add a clear and concise description of the problem you are seeking to solve with this feature request.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Proposed Solution
+    description: Describe the solution you'd like in a clear and concise manner.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Alternatives Considered
+    description: A clear and concise description of any alternative solutions or features you've considered.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Additional Information
+    description: Add any other context about the problem here.
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,6 +1,5 @@
 name: Feature Request
 description: Suggest an idea for Miniblox Translation Layer
-type: 'enhancement'
 labels: [enhancement]
 body:
 - type: checkboxes


### PR DESCRIPTION
# Stupid issue templates

I stole these from Electron's issue templates.
The following sections are the previews:

## Selection

![Issue template selection preview](https://github.com/user-attachments/assets/55b9ba66-67f4-4d35-a9b2-866be5cc520e)

## Bug report

![Bug report issue template preview](https://github.com/user-attachments/assets/9bb137bb-4b86-4fa6-947d-22e7e9642b66)

## Feature request

![Feature request issue template preview](https://github.com/user-attachments/assets/8961c5e0-926c-4aaf-8773-7cc4c61bb8c8)
