### PR TITLE
feat: documentation updates, add `/q` (alias to `/queue`/`/play`), and disable production database deleter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"chat.disableAIFeatures": true
+}

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A middle man to translate Miniblox packets into Minecraft 1.8.9 packets.
 
 ### /play, /queue, and /q
 
-Syntax: `/q [gamemode]` (`[gamemode]` can be autocompleted using the <kbd>TAB</kbd>)
+Syntax: `/q [gamemode]` (`[gamemode]` can be autocompleted using the <kbd>TAB</kbd> key)
 
 Joins a server matching the gamemode criteria.
 `skywars` is the default gamemode

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Syntax: `/login <token>`
 Writes `token` to `login.token` so the translation layer can use it once you rejoin.
 Rejoin for the changes to take effect.
 
-## /join
+### /join
 
 Syntax: `/join <server ID or invite code>`
 

--- a/README.md
+++ b/README.md
@@ -28,13 +28,15 @@ Syntax: `/login <token>`
 Writes `token` to `login.token` so the translation layer can use it once you rejoin.
 Rejoin for the changes to take effect.
 
-### /join
+## /join
 
-Syntax: `/join <server ID>`
+Syntax: `/join <server ID or invite code>`
 
 Joins a specific server.
 A server ID looks like this:
 `{server size, e.g. small, large, medium, or planet}-{ID 1}-{ID 2}`.
+An invite code looks like this: `https://miniblox.io/join/INVITECODE` or just `INVITECODE`.
+Crazy Gays invite links are not supported because no one wants it (just copy the invite code which is everything after `?join=` instead lol)
 
 ### /resync
 

--- a/README.md
+++ b/README.md
@@ -62,4 +62,4 @@ Sends you to the next game using `CPacketQueueNext`, note that sometimes the ser
 |----------------------|-----------|----------------------------------------------------------|-------------------------------------------------|
 | miniblox:send_packet | C->S      | Send a Miniblox packet                                   | packet name (string), data (JSON, string)       |
 | miniblox:receive_pkt | S->C      | A packet was sent by the server that wasn't blacklisted  | packet name (string), data (JSON, msg.toJSON()) |
-| layer:player         | S->C      | Sent on connect, replaces the deprecated layer:name_c2s. | None                                            |
+| layer:player         | S->C      | Sent on connect, replaces the deprecated layer:name_c2s. | player name (string), player UUID (string)      |

--- a/base/packets/s2c/player.js
+++ b/base/packets/s2c/player.js
@@ -6,10 +6,10 @@ const { writeString } = require('../buf_utils');
  * @returns {Buffer} packet to send over `layer:player`
  */
 module.exports = function writePlayer(remoteName, remoteUUID) {
-		const len = remoteName.length + 1 + remoteUUID.length + 1;
+	const len = remoteName.length + 1 + remoteUUID.length + 1;
 
-		const data = Buffer.alloc(len);
-		let off = writeString(data, 0, remoteName);
-		writeString(data, off, remoteUUID);
-		return data;
+	const data = Buffer.alloc(len);
+	const off = writeString(data, 0, remoteName);
+	writeString(data, off, remoteUUID);
+	return data;
 }

--- a/miniblox/handlers/impl/misc.js
+++ b/miniblox/handlers/impl/misc.js
@@ -55,6 +55,7 @@ async function handleCommand(name, args) {
 			world.chunks = [];
 			world.queued = [];
 			break;
+		case 'q':
 		case 'queue':
 		case 'play': {
 			// un-scruffily stuff happens if we don't wrap in {}


### PR DESCRIPTION
Mostly update to documentation lol, no need to test ts but I tested it anyway. Thingies:
- update documentation for `layer:player` because it does have contents in it, insane documentation error
- update documentation for `/join` since it supports invite codes now
- change `let` to `const` in `base/packets/s2c/player.js` (lol)
- fix a typo in `/q` / `/play` docs
- add `/q` (just an alias to `/play` / `/queue`)


<img width="409" height="161" alt="image" src="https://github.com/user-attachments/assets/9ae60645-3ce4-4dc5-8a9f-fc645d8e20ad" />

also this (portrait doesn't do really good when you are in a dark room because I don't bother turning on the lights)
<img width="3024" height="4032" alt="IMG_1520" src="https://github.com/user-attachments/assets/6b0d60e9-5cdb-439d-bf10-2e139c419657" />
